### PR TITLE
Bump up Maven version from 3.5 to 3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Clement Escoffier <clement@apache.org>
 
 # Install build tools on top of base image
 ENV GRADLE_VERSION 4.1
-ENV MAVEN_VERSION 3.5.0
+ENV MAVEN_VERSION 3.6.0
 
 RUN yum install -y --enablerepo=centosplus \
     tar unzip bc which lsof java-1.8.0-openjdk java-1.8.0-openjdk-devel && \


### PR DESCRIPTION
Maven version 3.5 was moved to the Apache archive in the meantime.
Fix the Docker image build by using Maven 3.6 instead.