### PR TITLE
Set default branch to master (was initial-work)

### DIFF
--- a/vertx-s2i-all.json
+++ b/vertx-s2i-all.json
@@ -116,7 +116,7 @@
                 {
                     "description": "Git branch/tag reference",
                     "name": "GIT_REF",
-                    "value": "initial-work"
+                    "value": "master"
                 },
                 {
                     "description": "Git Directory",


### PR DESCRIPTION
Command 'oc new-app vertx-helloworld-maven' would fail to
instantiate the application as the initial-work branch does not
exist. Fix it by making master the default branch.